### PR TITLE
fix: set isLenient on DateFormatter when parsing offline recording

### DIFF
--- a/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/impl/PolarBleApiImpl.swift
+++ b/sources/iOS/ios-communications/Sources/PolarBleSdk/sdk/impl/PolarBleApiImpl.swift
@@ -1231,6 +1231,7 @@ extension PolarBleApiImpl: PolarBleApi  {
                     let components = entry.name.split(separator: "/")
                     let dateFormatter = DateFormatter()
                     dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+                    dateFormatter.isLenient = true
 
                     if components[2].count == 8 && components[4].count == 6 {
                         dateFormatter.dateFormat = "yyyyMMddHHmmss"


### PR DESCRIPTION
Relates to [VA-1951](https://makevisible.atlassian.net/browse/VA-1951)

When isLenient = true, DateFormatter tries to adjust invalid times instead of failing. If a time does not exist due to DST (Daylight Saving Time) changes, it shifts to the closest valid time.


![CleanShot 2025-03-18 at 12 28 01@2x](https://github.com/user-attachments/assets/e6941059-fea7-4f1f-bd45-d8ba75464dd5)
