### PR TITLE
attempt to make commandState method thread-safe

### DIFF
--- a/sources/Android/android-communications/library/src/main/java/com/polar/androidcommunications/enpoints/ble/bluedroid/host/connection/ConnectionHandler.kt
+++ b/sources/Android/android-communications/library/src/main/java/com/polar/androidcommunications/enpoints/ble/bluedroid/host/connection/ConnectionHandler.kt
@@ -132,10 +132,11 @@ class ConnectionHandler(
 
     private val commandStateLock = ReentrantLock()
     private fun commandState(bleDeviceSession: BDDeviceSessionImpl, action: ConnectionHandlerAction) {
-        BleLogger.d(TAG, "commandState: thread ${Thread.currentThread().name} trying to acquire lock")
+        val threadName = Thread.currentThread().name
+        BleLogger.d(TAG, "commandState: thread $threadName trying to acquire lock")
         commandStateLock.lock()
         try {
-            BleLogger.d(TAG, "commandState: lock acquired by ${Thread.currentThread().name}")
+            BleLogger.d(TAG, "commandState: lock acquired by $threadName")
             when (state) {
                 ConnectionHandlerState.FREE -> {
                     free(bleDeviceSession, action)
@@ -147,7 +148,7 @@ class ConnectionHandler(
             }
         } finally {
             commandStateLock.unlock()
-            BleLogger.d(TAG, "commandState: lock released by ${Thread.currentThread().name}")
+            BleLogger.d(TAG, "commandState: lock released by $threadName")
         }
     }
 


### PR DESCRIPTION
Teams thread [here](https://teams.microsoft.com/l/message/19:EHiLjS6Wj6QrQYjECqozRSReYd_TYU356MIxinkWHfw1@thread.tacv2/1751288065481?tenantId=09970eda-a4a6-4890-a2e2-cc2ac3a2ba32&groupId=87caacc7-dea3-4ba5-8dc6-9fe504fc1585&parentMessageId=1751288065481&teamName=EXTERNAL%20Makevisible-Polar&channelName=General&createdTime=1751288065481) for more context.

<details><summary>Logs</summary>
<p>

```
2025-07-01 14:13:51.311  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by main
2025-07-01 14:13:51.814  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread main trying to acquire lock
2025-07-01 14:13:51.814  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by main
2025-07-01 14:13:51.814  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by main
2025-07-01 14:13:52.319  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread main trying to acquire lock
2025-07-01 14:13:52.319  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by main
2025-07-01 14:13:52.320  7784-7784  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by main
2025-07-01 14:13:53.227  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread DefaultDispatcher-worker-1 trying to acquire lock
2025-07-01 14:13:53.227  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by DefaultDispatcher-worker-1
2025-07-01 14:13:53.227  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread DefaultDispatcher-worker-1 trying to acquire lock
2025-07-01 14:13:53.228  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by DefaultDispatcher-worker-1
2025-07-01 14:13:53.228  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by DefaultDispatcher-worker-1
2025-07-01 14:13:53.228  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread DefaultDispatcher-worker-1 trying to acquire lock
2025-07-01 14:13:53.228  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by DefaultDispatcher-worker-1
2025-07-01 14:13:53.228  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: state: CONNECTING action: ENTRY
2025-07-01 14:13:53.243  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by DefaultDispatcher-worker-1
2025-07-01 14:13:53.243  7784-7907  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by DefaultDispatcher-worker-1
2025-07-01 14:13:54.473  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread RxCachedThreadScheduler-1 trying to acquire lock
2025-07-01 14:13:54.473  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by RxCachedThreadScheduler-1
2025-07-01 14:13:54.473  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: state: CONNECTING action: DEVICE_CONNECTION_INITIALIZED
2025-07-01 14:13:54.476  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by RxCachedThreadScheduler-1
2025-07-01 14:13:54.988  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread RxCachedThreadScheduler-2 trying to acquire lock
2025-07-01 14:13:54.988  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by RxCachedThreadScheduler-2
2025-07-01 14:13:54.988  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: state: CONNECTING action: SERVICES_DISCOVERED
2025-07-01 14:13:54.991  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by RxCachedThreadScheduler-2
2025-07-01 14:13:55.400  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread RxCachedThreadScheduler-1 trying to acquire lock
2025-07-01 14:13:55.401  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by RxCachedThreadScheduler-1
2025-07-01 14:13:55.401  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: state: CONNECTING action: PHY_UPDATED
2025-07-01 14:13:55.405  7784-7865  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by RxCachedThreadScheduler-1
2025-07-01 14:13:55.458  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread RxCachedThreadScheduler-2 trying to acquire lock
2025-07-01 14:13:55.458  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by RxCachedThreadScheduler-2
2025-07-01 14:13:55.458  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: state: CONNECTING action: MTU_UPDATED
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread RxCachedThreadScheduler-2 trying to acquire lock
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by RxCachedThreadScheduler-2
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: state: CONNECTING action: EXIT
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by RxCachedThreadScheduler-2
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: thread RxCachedThreadScheduler-2 trying to acquire lock
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock acquired by RxCachedThreadScheduler-2
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by RxCachedThreadScheduler-2
2025-07-01 14:13:55.479  7784-7869  API_LOGGER              com.polar.polarsensordatacollector   D  ConnectionHandler/commandState: lock released by RxCachedThreadScheduler-2
```
</p>
</details> 